### PR TITLE
Use proxy image from Docker Hub

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,6 +39,11 @@ provider "cloudflare" {
   api_key = var.cf_api_key
 }
 
+variable "private_relay_docker_image_name" {
+  description = "The publicly-accessible Docker image name to run on each server"
+  type        = string
+}
+
 variable "region_map_keys" {
   description = "The set of Cloudflare origin pool regions"
 
@@ -86,7 +91,9 @@ resource "digitalocean_droplet" "private_relay_server" {
     "21:ba:db:a6:e6:f4:8f:ac:77:c9:1a:70:f1:81:a0:73"
   ]
 
-  user_data = file("scripts/nginx")
+  user_data = templatefile("userdata.bash", {
+    docker_image_name = var.private_relay_docker_image_name
+  })
 
   backups            = false
   ipv6               = false

--- a/terraform/userdata.bash
+++ b/terraform/userdata.bash
@@ -23,4 +23,7 @@ apt install --yes \
     docker-ce{,-cli} \
     containerd.io
 
-docker run --publish 80:80 --detach nginx:1.18
+# This comes from Terraform
+# shellcheck disable=SC2016
+IMAGE='${docker_image_name}'
+docker run --restart 'on-failure' --publish 443:443 --detach "$IMAGE"


### PR DESCRIPTION
This PR updates the servers to pull the latest image from Docker Hub (see #6).

This should result in each server running a `httpbin.org` proxy image (as configured in Terraform Cloud).