### PR TITLE
Add region to server names

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -85,7 +85,7 @@ resource "digitalocean_droplet" "private_relay_server" {
 
   region = each.key
   image  = "ubuntu-20-04-x64"
-  name   = "private-relay-1"
+  name   = "private-relay-${each.key}"
   size   = "s-1vcpu-1gb"
   ssh_keys = [
     "21:ba:db:a6:e6:f4:8f:ac:77:c9:1a:70:f1:81:a0:73"


### PR DESCRIPTION
This PR adds the region to the server names so instead of `-1` for all of the servers, we have `-tor1`, for example.