### PR TITLE
Add more Cloudflare regions

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,18 +64,36 @@ variable "region_map_values" {
   default = [
     {
       # North American region
-      do_regions    = ["tor1", "sfo3"]
-      check_regions = ["WNAM"]
+      do_regions = ["tor1", "sfo3"]
+      check_regions = [
+        "WNAM", "ENAM", # North America
+        "SSAM",         # South America
+        "OC",           # Oceania
+        "WEU", "EEU",   # Europe
+        "SEAS", "NEAS", # Asia
+      ]
     },
     {
       # EU region
-      do_regions    = ["ams3", "fra1"]
-      check_regions = ["WEU"]
+      do_regions = ["ams3", "fra1"]
+      check_regions = [
+        "WNAM", "ENAM", # North America
+        "SSAM",         # South America
+        "OC",           # Oceania
+        "WEU", "EEU",   # Europe
+        "SEAS", "NEAS", # Asia
+      ]
     },
     {
       # Asia-Pacific region
-      do_regions    = ["sgp1"]
-      check_regions = ["SEAS"]
+      do_regions = ["sgp1"]
+      check_regions = [
+        "WNAM", "ENAM", # North America
+        "SSAM",         # South America
+        "OC",           # Oceania
+        "WEU", "EEU",   # Europe
+        "SEAS", "NEAS", # Asia
+      ]
     },
   ]
 }


### PR DESCRIPTION
This PR adds more `check_regions` to the `cloudflare_load_balancer_pool`s.

Upon closer inspection of the docs for Dynamic Steering:

> Dynamic Steering creates Round Trip Time (RTT) profiles based on an exponential weighted moving average (EWMA) of RTT to determine the fastest pool. **If there is no current RTT data for your pool in a region or colocation center, Cloudflare directs traffic to the pools in failover order.**

Note that if a user's region doesn't have RTT data they'll be directed to the pools in failover order, meaning that the `check_regions` should try to represent as many users as possible.