### PR TITLE
Reorder regions to affect default region

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,8 +53,8 @@ variable "region_map_keys" {
   # Cloudflare will send traffic to the next available pool - e.g. traffic
   # will always land on Pool #1 until it is marked unhealthy.
   default = [
-    "na",
     "eu",
+    "na",
     "ap",
   ]
 }
@@ -63,8 +63,8 @@ variable "region_map_values" {
   description = "The set of supported regions"
   default = [
     {
-      # North American region
-      do_regions = ["tor1", "sfo3"]
+      # EU region
+      do_regions = ["ams3", "fra1"]
       check_regions = [
         "WNAM", "ENAM", # North America
         "SSAM",         # South America
@@ -74,8 +74,8 @@ variable "region_map_values" {
       ]
     },
     {
-      # EU region
-      do_regions = ["ams3", "fra1"]
+      # North American region
+      do_regions = ["tor1", "sfo3"]
       check_regions = [
         "WNAM", "ENAM", # North America
         "SSAM",         # South America


### PR DESCRIPTION
This PR reorders the region map to make the EU region the "default region" for traffic.

Reading the docs for Dynamic Steering:<sup>[\[1\]][1]</sup>

> Dynamic Steering creates Round Trip Time (RTT) profiles based on an exponential weighted moving average (EWMA) of RTT to determine the fastest pool. If there is no current RTT data for your pool in a region or colocation center, Cloudflare directs traffic to the pools in failover order.

This leads me to believe that any regions that are missing RTT data—essentially any regions not included in the 8 `region_map_values.check_regions` regions—will always be directed to the default region.

As configured this would mean that all of the following regions are always directed to the default region:

Region Code | Region
-- | --
NSAM | Northern South America
ME | Middle East
NAF | Northern Africa
SAF | Southern Africa
IN | India

That's a lot of regions. That's also not at all close to NA.

As proposed here, it would make more sense for these to be directed to the EU region.

  [1]:https://developers.cloudflare.com/load-balancing/understand-basics/traffic-steering/#dynamic-steering