### PR TITLE
Use only Node 12 for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,13 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 12
       - name: Use Terraform
         uses: hashicorp/setup-terraform@v1
         with:


### PR DESCRIPTION
This PR updates the test workflow to use only 1 version of Node.js, v12.