### PR TITLE
Use Cloudflare DNS explictly

### DIFF
--- a/proxy/haproxy.cfg.tmpl
+++ b/proxy/haproxy.cfg.tmpl
@@ -4,6 +4,19 @@ defaults
     timeout client  50000
     timeout server  50000
 
+resolvers cloudflare
+    nameserver cf1 1.1.1.1:53
+    nameserver cf2 1.0.0.1:53
+    resolve_retries      3
+    timeout resolve      1s
+    timeout retry        1s
+    hold valid          10s
+    hold obsolete        0s
+    hold refused        30s
+    hold nx             30s
+    hold timeout        30s
+    hold other          30s
+
 frontend tcp_relay
     bind 0.0.0.0:443
     %{ for backend in backends }


### PR DESCRIPTION
This change updates the HAProxy config to:

1. Use Cloudflare DNS
2. Set lifecycle for DNS resolution, explictly

The config as written here sees a valid DNS resolution re-resolved every 10s.

Per the docs:<sup>[\[1\]][1]</sup>

>     [...] By default, HAProxy resolves the name when parsing the
>     configuration file, at startup and caches the result for the process' life.
>     This is not sufficient in some cases, such as in [the cloud] where a server's IP
>     can change [...].

>     Whether run time server name resolution has been enable or not, HAProxy will
>     carry on doing the first resolution when parsing the configuration.

>     hold <status> <period>
>     Defines <period> during which the last name resolution should be kept based
>     on last resolution <status>
>       <status> : last name resolution status. Acceptable values are "nx",
>                  "other", "refused", "timeout", "valid", "obsolete".
>       <period> : interval between two successive name resolution when the last
>                  answer was in <status>. It follows the HAProxy time format.
>                  <period> is in milliseconds by default.
>
>     Default value is 10s for "valid", 0s for "obsolete" and 30s for others.

  [1]:https://www.haproxy.com/documentation/hapee/latest/onepage/#5.3