### PR TITLE
Add ifconfig.co as a backend

### DIFF
--- a/proxy/main.tf
+++ b/proxy/main.tf
@@ -26,6 +26,11 @@ variable "backends" {
       port = "443"
     },
     {
+      name = "ifconfig"
+      host = "ifconfig.co"
+      port = "443"
+    },
+    {
       name = "ipify"
       host = "api.ipify.org"
       port = "443"


### PR DESCRIPTION
This PR adds [ifconfig.co](https://ifconfig.co) as another example backend.