### PR TITLE
Use node-fetch

### DIFF
--- a/proxy/test/index.js
+++ b/proxy/test/index.js
@@ -1,115 +1,115 @@
 import { strict as assert } from 'assert';
 import baretest from 'baretest';
-import bent from 'bent';
+import fetch from 'node-fetch';
 
 const { GITHUB_API_ENDPOINT, GITHUB_API_ENDPOINT_RELAY, HTTPBIN_ENDPOINT, HTTPBIN_ENDPOINT_RELAY } = process.env;
 
 const test = baretest('Proxy tests');
 
 test('query GitHub API via the actual GitHub endpoint', async function () {
-    const headers = { 'user-agent': 'curl/7.58.0', host: 'api.github.com' };
+    const headers = { 'content-type': 'application/json', 'user-agent': 'curl/7.58.0', host: 'api.github.com' };
     const body = null;
-    const request = bent('json');
-    const response = await request(GITHUB_API_ENDPOINT, body, headers);
+    const r = await fetch(GITHUB_API_ENDPOINT, { headers, body });
+    const response = await r.json();
 
     assert.ok(response.issue_search_url);
 });
 
 test('query GitHub API via the relayed GitHub endpoint', async function () {
-    const headers = { 'user-agent': 'curl/7.58.0', host: 'api.github.com' };
+    const headers = { 'content-type': 'application/json', 'user-agent': 'curl/7.58.0', host: 'api.github.com' };
     const body = null;
-    const request = bent('json');
-    const response = await request(GITHUB_API_ENDPOINT_RELAY, body, headers);
+    const r = await fetch(GITHUB_API_ENDPOINT_RELAY, { headers, body });
+    const response = await r.json();
 
     assert.ok(response.issue_search_url);
 });
 
 test('DELETE httpbin.org', async function () {
-    const headers = { };
-    const body = { answer: '42' };
-    const request = bent('DELETE', 'json');
-    const response = await request(`${HTTPBIN_ENDPOINT}/anything`, body, headers);
+    const headers = { 'content-type': 'application/json' };
+    const body = JSON.stringify({ answer: '42' });
+    const r = await fetch(`${HTTPBIN_ENDPOINT}/anything`, { method: 'DELETE', headers, body });
+    const response = await r.json();
 
     assert.deepEqual(response.json.answer, '42');
 });
 
 test('DELETE httpbin.org relayed', async function () {
-    const headers = { host: 'httpbin.org' };
-    const body = { answer: '42' };
-    const request = bent('DELETE', 'json');
-    const response = await request(`${HTTPBIN_ENDPOINT_RELAY}/anything`, body, headers);
+    const headers = { 'content-type': 'application/json', host: 'httpbin.org' };
+    const body = JSON.stringify({ answer: '42' });
+    const r = await fetch(`${HTTPBIN_ENDPOINT_RELAY}/anything`, { method: 'DELETE', headers, body });
+    const response = await r.json();
 
     assert.deepEqual(response.json.answer, '42');
 });
 
 test('GET httpbin.org', async function () {
-    const headers = { };
+    const headers = { 'content-type': 'application/json' };
     const body = null;
-    const request = bent('json');
-    const response = await request(`${HTTPBIN_ENDPOINT}/anything?answer=42`, body, headers);
+    const r = await fetch(`${HTTPBIN_ENDPOINT}/anything?answer=42`, { body, headers });
+    const response = await r.json();
 
     assert.equal(response.args.answer, '42');
 });
 
 test('GET httpbin.org relayed', async function () {
-    const headers = { host: 'httpbin.org' };
+    const headers = { 'content-type': 'application/json', host: 'httpbin.org' };
     const body = null;
-    const request = bent('json');
-    const response = await request(`${HTTPBIN_ENDPOINT_RELAY}/anything?answer=42`, body, headers);
+    const r = await fetch(`${HTTPBIN_ENDPOINT_RELAY}/anything?answer=42`, { body, headers });
+    const response = await r.json();
 
     assert.equal(response.args.answer, '42');
 });
 
 test('PATCH httpbin.org', async function () {
-    const headers = { };
-    const body = { answer: '42' };
-    const request = bent('PATCH', 'json');
-    const response = await request(`${HTTPBIN_ENDPOINT}/anything`, body, headers);
+    const headers = { 'content-type': 'application/json' };
+    const body = JSON.stringify({ answer: '42' });
+    const r = await fetch(`${HTTPBIN_ENDPOINT}/anything`, { method: 'PATCH', headers, body });
+    const response = await r.json();
 
     assert.deepEqual(response.json.answer, '42');
 });
 
 test('PATCH httpbin.org relayed', async function () {
-    const headers = { host: 'httpbin.org' };
-    const body = { answer: '42' };
-    const request = bent('PATCH', 'json');
-    const response = await request(`${HTTPBIN_ENDPOINT_RELAY}/anything`, body, headers);
+    const headers = { 'content-type': 'application/json', host: 'httpbin.org' };
+    const body = JSON.stringify({ answer: '42' });
+    const r = await fetch(`${HTTPBIN_ENDPOINT_RELAY}/anything`, { method: 'PATCH', headers, body });
+    const response = await r.json();
 
     assert.deepEqual(response.json.answer, '42');
 });
 
 test('POST httpbin.org', async function () {
-    const headers = { };
-    const body = { answer: '42' };
-    const request = bent('POST', 'json');
-    const response = await request(`${HTTPBIN_ENDPOINT}/anything`, body, headers);
+    const headers = { 'content-type': 'application/json' };
+    const body = JSON.stringify({ answer: '42' });
+    const r = await fetch(`${HTTPBIN_ENDPOINT}/anything`, { method: 'POST', headers, body });
+    const response = await r.json();
 
     assert.deepEqual(response.json.answer, '42');
 });
 
 test('POST httpbin.org relayed', async function () {
-    const headers = { host: 'httpbin.org' };
-    const body = { answer: '42' };
-    const request = bent('POST', 'json');
-    const response = await request(`${HTTPBIN_ENDPOINT_RELAY}/anything`, body, headers);
+    const headers = { 'content-type': 'application/json', host: 'httpbin.org' };
+    const body = JSON.stringify({ answer: '42' });
+    const r = await fetch(`${HTTPBIN_ENDPOINT_RELAY}/anything`, { method: 'POST', headers, body });
+    const response = await r.json();
 
     assert.deepEqual(response.json.answer, '42');
 });
 
 test('PUT httpbin.org', async function () {
-    const headers = { };
-    const body = { answer: '42' };
-    const request = bent('PUT', 'json');
-    const response = await request(`${HTTPBIN_ENDPOINT}/anything`, body, headers);
+    const headers = { 'content-type': 'application/json' };
+    const body = JSON.stringify({ answer: '42' });
+    const r = await fetch(`${HTTPBIN_ENDPOINT}/anything`, { method: 'PUT', headers, body });
+    const response = await r.json();
 
     assert.deepEqual(response.json.answer, '42');
 });
 
 test('PUT httpbin.org relayed', async function () {
-    const headers = { host: 'httpbin.org' };
-    const body = { answer: '42' };
-    const request = bent('PUT', 'json');
-    const response = await request(`${HTTPBIN_ENDPOINT_RELAY}/anything`, body, headers);
+    const headers = { 'content-type': 'application/json', host: 'httpbin.org' };
+    const body = JSON.stringify({ answer: '42' });
+    const r = await fetch(`${HTTPBIN_ENDPOINT_RELAY}/anything`, { method: 'PUT', headers, body });
+    const response = await r.json();
 
     assert.deepEqual(response.json.answer, '42');
 });

--- a/proxy/test/package.json
+++ b/proxy/test/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "baretest": "^2.0.0",
-    "bent": "^7.3.1"
+    "node-fetch": "^2.6.0"
   }
 }

--- a/proxy/test/yarn.lock
+++ b/proxy/test/yarn.lock
@@ -14,26 +14,7 @@ baretest@^2.0.0:
   dependencies:
     barecolor "1.0.1"
 
-bent@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/bent/-/bent-7.3.1.tgz#a4d2c83874d3f216baf5c78e7ab13335279ddb45"
-  integrity sha512-4nv/p7GaItr5FJ/CPiP0t3LZ1gETMaV+zXJU0X9tHiOuAPYZ8NA8ohIyugBMBV7q64X2OiDvBaqoQSUM2LuLjA==
-  dependencies:
-    bytesish "^0.4.1"
-    caseless "~0.12.0"
-    is-stream "^2.0.0"
-
-bytesish@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/bytesish/-/bytesish-0.4.1.tgz#5fe19b076037ffdfb63e083a53495b1d1c063f6f"
-  integrity sha512-j3l5QmnAbpOfcN/Z2Jcv4poQYfefs8rDdcbc6iEKm+OolvUXAE2APodpWj+DOzqX6Bl5Ys1cQkcIV2/doGvQxg==
-
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-is-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
-  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==


### PR DESCRIPTION
This PR updates the the tests, replacing `bent` with `node-fetch`.

The fetch API is standardized* and is what `private-request` uses.

\* Though this implementation isn't fully compliant with the spec.