### PR TITLE
Update tests to use TypeScript

### DIFF
--- a/proxy/test/.gitignore
+++ b/proxy/test/.gitignore
@@ -1,1 +1,4 @@
+*.js
+*.d.ts
+*.tsbuildinfo
 node_modules/

--- a/proxy/test/index.ts
+++ b/proxy/test/index.ts
@@ -9,7 +9,7 @@ const test = baretest('Proxy tests');
 test('query GitHub API via the actual GitHub endpoint', async function () {
     const headers = { 'content-type': 'application/json', 'user-agent': 'curl/7.58.0', host: 'api.github.com' };
     const body = null;
-    const r = await fetch(GITHUB_API_ENDPOINT, { headers, body });
+    const r = await fetch(GITHUB_API_ENDPOINT!, { headers, body });
     const response = await r.json();
 
     assert.ok(response.issue_search_url);
@@ -18,7 +18,7 @@ test('query GitHub API via the actual GitHub endpoint', async function () {
 test('query GitHub API via the relayed GitHub endpoint', async function () {
     const headers = { 'content-type': 'application/json', 'user-agent': 'curl/7.58.0', host: 'api.github.com' };
     const body = null;
-    const r = await fetch(GITHUB_API_ENDPOINT_RELAY, { headers, body });
+    const r = await fetch(GITHUB_API_ENDPOINT_RELAY!, { headers, body });
     const response = await r.json();
 
     assert.ok(response.issue_search_url);

--- a/proxy/test/package.json
+++ b/proxy/test/package.json
@@ -2,10 +2,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --harmony-top-level-await index.js"
+    "build": "tsc --project .",
+    "test": "yarn build && node --harmony-top-level-await index.js"
   },
   "devDependencies": {
+    "@types/node": "^14.0.27",
     "baretest": "^2.0.0",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "typescript": "^3.9.7"
   }
 }

--- a/proxy/test/tsconfig.json
+++ b/proxy/test/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "incremental": true,
+    "target": "ES2017",
+    "module": "esnext",
+    "declaration": false,
+
+    /* Strict Type-Checking Options */
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+
+    /* Additional Checks */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+
+    /* Module Resolution Options */
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/proxy/test/types/baretest.d.ts
+++ b/proxy/test/types/baretest.d.ts
@@ -1,0 +1,16 @@
+declare module 'baretest' {
+  export interface Test {
+    (name: string, fn: () => Promise<void>): void;
+    run(): Promise<boolean>;
+    skip(fn: () => Promise<void>): void;
+    // This isn't real, but skip ignores its args
+    skip(name: string, fn: () => Promise<void>): void;
+    // This isn't real, but skip ignores its args
+    skip(name: string): void;
+    before(fn: () => Promise<void>): void;
+    after(fn: () => Promise<void>): void;
+    only(name: string, fn: () => Promise<void>): void;
+  }
+
+  export default function (headline: string): Test;
+}

--- a/proxy/test/types/node-fetch.d.ts
+++ b/proxy/test/types/node-fetch.d.ts
@@ -1,0 +1,3 @@
+declare module 'node-fetch' {
+  export default function(input: RequestInfo, init?: RequestInit): Promise<Response>;
+}

--- a/proxy/test/yarn.lock
+++ b/proxy/test/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/node@^14.0.27":
+  version "14.0.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
+  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
+
 barecolor@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/barecolor/-/barecolor-1.0.1.tgz#1bbbbfc41cedecf74e23fb7d9d054cd8763d92cc"
@@ -18,3 +23,8 @@ node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
Closes #28

This PR migrates the tests to TypeScript.