### PR TITLE
Rewrite proxy setup to include Terraform in image

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -15,9 +15,10 @@ jobs:
       - name: Publish to Docker Hub
         working-directory: proxy
         run: |
-          docker build --tag "${GITHUB_REPOSITORY}:${TAG}" .
+          docker build --tag "${DOCKER_IMAGE}" .
           docker login --username "$( dirname $GITHUB_REPOSITORY )" --password-stdin <<< "${DOCKER_TOKEN}"
-          docker push "${GITHUB_REPOSITORY}:${TAG}"
+          docker push "${DOCKER_IMAGE}"
         env:
+          DOCKER_IMAGE: privaterelay/privaterelay
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
           TAG: 'latest'

--- a/proxy/.dockerignore
+++ b/proxy/.dockerignore
@@ -1,4 +1,6 @@
 *
+!*.tfvars
+!build-config
 !main.tf
 !haproxy.cfg
 !haproxy.cfg.tmpl

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -8,14 +8,12 @@ RUN apt-get -qq update && \
     sha256sum --strict --check --ignore-missing "terraform_${TERRAFORM_VERSION}_SHA256SUMS" && \
     unzip -q -n -d '/usr/local/bin' "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 
-FROM terraform as build
-ARG TF_VAR_backends
-WORKDIR /proxy
-COPY main.tf .
-COPY haproxy.cfg.tmpl .
-RUN terraform init && \
-    terraform apply -auto-approve
-
-FROM haproxy:2.2
-COPY --from=build /proxy/haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
-RUN haproxy -c -f '/usr/local/etc/haproxy/haproxy.cfg'
+FROM haproxy:2.2-alpine
+WORKDIR /app
+ENV CHECKPOINT_DISABLE=1
+ENV TF_INPUT=0
+ENV TF_IN_AUTOMATION=1
+ENV TF_LOG=
+COPY --from=terraform /usr/local/bin/terraform /usr/local/bin/terraform
+COPY . .
+RUN apk add --no-cache bash && ./build-config

--- a/proxy/TESTING.md
+++ b/proxy/TESTING.md
@@ -1,0 +1,28 @@
+ # Testing the image
+
+To run the tests ([`test/`](./test)) against the default config, build the image:
+
+```bash
+docker build --tag private-relay .
+```
+
+Run HAProxy:
+
+```bash
+docker run --rm --detach --publish 8080:443 --name private-relay private-relay
+```
+
+And run the tests:
+
+```bash
+pushd test/
+yarn
+
+GITHUB_API_ENDPOINT='https://api.github.com' \
+GITHUB_API_ENDPOINT_RELAY="https://127.0.0.1:8080" \
+HTTPBIN_ENDPOINT="https://httpbin.org" \
+HTTPBIN_ENDPOINT_RELAY="https://127.0.0.1:8080" \
+yarn test
+
+popd
+```

--- a/proxy/build-config
+++ b/proxy/build-config
@@ -10,3 +10,5 @@ terraform init
 terraform apply -auto-approve
 cp haproxy.cfg "$haproxy_config"
 haproxy -c -f "$haproxy_config"
+
+rm -r .terraform terraform.tfstate

--- a/proxy/build-config
+++ b/proxy/build-config
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+declare -r haproxy_config='/usr/local/etc/haproxy/haproxy.cfg'
+
+terraform init
+terraform apply -auto-approve
+cp haproxy.cfg "$haproxy_config"
+haproxy -c -f "$haproxy_config"

--- a/proxy/main.tf
+++ b/proxy/main.tf
@@ -15,29 +15,6 @@ variable "backends" {
     host = string
     port = string
   }))
-
-  default = [
-    {
-      name = "github"
-      host = "api.github.com"
-      port = "443"
-    },
-    {
-      name = "httpbin"
-      host = "httpbin.org"
-      port = "443"
-    },
-    {
-      name = "ifconfig"
-      host = "ifconfig.co"
-      port = "443"
-    },
-    {
-      name = "ipify"
-      host = "api.ipify.org"
-      port = "443"
-    },
-  ]
 }
 
 resource "local_file" "haproxy_config" {

--- a/proxy/terraform.tfvars
+++ b/proxy/terraform.tfvars
@@ -1,0 +1,22 @@
+backends = [
+  {
+    name = "github"
+    host = "api.github.com"
+    port = "443"
+  },
+  {
+    name = "httpbin"
+    host = "httpbin.org"
+    port = "443"
+  },
+  {
+    name = "ifconfig"
+    host = "ifconfig.co"
+    port = "443"
+  },
+  {
+    name = "ipify"
+    host = "api.ipify.org"
+    port = "443"
+  },
+]

--- a/terraform/modules/cloudflare-digitalocean/variables.tf
+++ b/terraform/modules/cloudflare-digitalocean/variables.tf
@@ -21,6 +21,7 @@ variable "do_tag_name" {
 variable "private_relay_docker_image_name" {
   description = "The publicly-accessible Docker image name to run on each server"
   type        = string
+  default     = "privaterelay/privaterelay"
 }
 
 variable "region_map_keys" {


### PR DESCRIPTION
This PR rewrites the proxy README to clarify how the image can be built upon.

With these changes, it's now possible to use the image as a base and to inject a custom config at build time:

> 1. Create a `terraform.tfvars` file with a set of backend servers
> 2. Use this as a base image, `COPY terraform.tfvars /app/`, and `RUN /app/build-config`
> 3. Start your container

An example `terraform.tfvars`:

```tf
backends = [
  {
    name = "example"
    host = "example.com"
    port = "443"
  },
]
```

An example `Dockerfile`:

```Dockerfile
FROM privaterelay/privaterelay
COPY terraform.tfvars /app/
RUN /app/build-config
```