### PR TITLE
Combine region_map_keys and region_map_values into region_map

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -68,15 +68,17 @@ module "private_relay" {
   private_relay_docker_image_name = var.private_relay_docker_image_name
 
   # A single Asia-Pacific region with a single droplet
-  region_map_keys = ["ap"]
-  region_map_values = [{
-    do_regions = ["sgp1"]
-    check_regions = [
-      "WNAM", "ENAM", # North America
-      "SSAM",         # South America
-      "OC",           # Oceania
-      "WEU", "EEU",   # Europe
-      "SEAS", "NEAS", # Asia
-    ]
-  }]
+  origin_pools = [
+    {
+      name       = "ap"
+      do_regions = ["sgp1"]
+      check_regions = [
+        "WNAM", "ENAM", # North America
+        "SSAM",         # South America
+        "OC",           # Oceania
+        "WEU", "EEU",   # Europe
+        "SEAS", "NEAS", # Asia
+      ]
+    },
+  ]
 }

--- a/terraform/modules/cloudflare-digitalocean/README.md
+++ b/terraform/modules/cloudflare-digitalocean/README.md
@@ -29,13 +29,13 @@ module "private_relay" {
   cf_zone_id                      = "fh7eew2xxxxxxx98fdx2fh7eew2xxxxx"
   cf_lb_name                      = "relay.example.com"
   private_relay_docker_image_name = "org/custom-private-relay-backends"
-  region_map_keys = [
-    "eu",
-  ]
-  region_map_values = [
+  origin_pools = [
+    # EU region
     {
-      # EU region
+      name = "eu"
+      # Backed by these DigitalOcean regions
       do_regions = ["ams3", "fra1"]
+      # RTT-tested from these regions
       check_regions = [
         "WNAM", "ENAM", # North America
         "SSAM",         # South America


### PR DESCRIPTION
This change combines the `region_map_keys` and `region_map_values` into a single
type that has the keys and values together while ALSO preserving the order of
the keys. The order is important for setting the fallback pool as well as to indicate
the failover priority order (`cloudflare_load_balancer.default_pool_ids`).

Note: the built-in map type does not have a way to retrieve keys while
preserving the order. As we need the first pool to use it as the fallback
we cannot simply use a map.