### PR TITLE
Fix incorrect cURL test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,6 @@ jobs:
         run: |
           docker build --tag private-relay .
           docker run --name private-relay --rm --detach --publish 8080:443 private-relay
-      - name: Run cURL test for GitHub API
-        run: |
-          curl -visSL \
-          --fail \
-          --connect-to api.github.com:443:127.0.0.1:8080 \
-          --header 'Host: api.github.com' \
-          https://api.github.com
       - name: Run tests
         working-directory: proxy/test/
         run: |
@@ -66,6 +59,13 @@ jobs:
           yarn test
         env:
           CI: true
+      - name: Run cURL test for GitHub API
+        run: |
+          curl -visSL \
+          --fail \
+          --connect-to api.github.com:443:127.0.0.1:8080 \
+          --header 'Host: api.github.com' \
+          https://api.github.com
       - name: Stop Docker container
         working-directory: proxy
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           curl -visSL \
           --fail \
-          --connect-to httpbin.org:443:127.0.0.1:8080 \
+          --connect-to api.github.com:443:127.0.0.1:8080 \
           --header 'Host: api.github.com' \
           https://api.github.com
       - name: Run tests


### PR DESCRIPTION
This PR fixes the `connect-to` value passed to cURL to correctly connect to localhost for the GitHub API. The tests have been reordered to have the cURL test last as cURL is less resilient to HAProxy not being up and running yet.